### PR TITLE
Feed Image Data Loading and Caching with URLSession/CoreData + Composing Modules Into a Running iOS Application with Xcode Workspaces (Part 2)

### DIFF
--- a/EssentialFeed/EssentialFeedTests/FeedAPI/URLSessionHTTPClientTests.swift
+++ b/EssentialFeed/EssentialFeedTests/FeedAPI/URLSessionHTTPClientTests.swift
@@ -95,7 +95,11 @@ class URLSessionHTTPClientTests: XCTestCase {
     }
     
     func test_cancelGetFromURLTask_cancelsURLRequest() {
+        let exp = expectation(description: "Wait for request")
+        URLProtocolStub.observeRequests { _ in exp.fulfill() }
+        
         let receivedError = resultErrorFor(taskHandler: { $0.cancel() }) as NSError?
+        wait(for: [exp], timeout: 1.0)
 
         XCTAssertEqual(receivedError?.code, URLError.cancelled.rawValue)
     }


### PR DESCRIPTION
Wait for `URLProtocol` to complete the `URLRequest` after a `task` has been canceled to avoid a test leak where the `URLProtocol` would start the request after the test finishes. This happens because canceling a `URLSessionDataTask` won't immediately cancel the `URLProtocol` from receiving that request. So if we don't wait for it, there's a chance the `URLProtocol` request will run while another test is running and influence its result.